### PR TITLE
fix: updated attribut name for textarea

### DIFF
--- a/P2/P2C6/contact.php
+++ b/P2/P2C6/contact.php
@@ -23,7 +23,7 @@
             </div>
             <div class="mb-3">
                 <label for="message" class="form-label">Votre message</label>
-                <textarea class="form-control" placeholder="Exprimez vous" id="message" name="textarea"></textarea>
+                <textarea class="form-control" placeholder="Exprimez vous" id="message" name="message"></textarea>
             </div>
             <button type="submit" class="btn btn-primary">Envoyer</button>
         </form>


### PR DESCRIPTION
Hello, I updated the value of name attribut.

Because when you get the message here: 

```<p class="card-text"><b>Message</b> : <?php echo $_GET['message']; ?></p>```

the value of the attribut ``name`` is '**textarea**' and we get this error : 

**_Notice: Undefined index: message '...' on line 8_**

and at the URL: http://localhost/contact.php?email=testing%40testing.com&textarea=Testing+message

we can see that we have **'textarea'** as a parameter and not **'message'**

Thank you !

![image](https://github.com/OpenClassrooms-Student-Center/Concevez-votre-site-web-avec-PHP-MySQL/assets/59540282/8bb580d8-6c06-4619-86da-abbff5f82db4)
